### PR TITLE
Add hostname to logged lines and email subject.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+zfswatcher (0.4.7-1) unstable; urgency=medium
+
+  * New version 0.4.7
+  * Fixed dependencies on Proxmox
+
+ -- Rouben Tchakhmakhtchian <rouben@rouben.net>  Sun, 13 Jun 2021 13:53:00 -0400
+
 zfswatcher (0.4.6-1) unstable; urgency=medium
 
   * New version 0.4.6.

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://zfswatcher.damicon.fi/
 
 Package: zfswatcher
 Architecture: amd64
-Depends: zfs | ubuntu-zfs | debian-zfs | zfs-dkms, ${shlibs:Depends}, ${misc:Depends}
+Depends: zfs | zfsutils-linux | ubuntu-zfs | debian-zfs | zfs-dkms, ${shlibs:Depends}, ${misc:Depends}
 Recommends: ledmon
 Description: ZFS pool monitoring and notification daemon
  Zfswatcher is ZFS pool monitoring and notification daemon

--- a/notifier/logger_smtp.go
+++ b/notifier/logger_smtp.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"strings"
 	"time"
+	"os"
 )
 
 func (n *Notifier) sendEmailSMTP(server, username, password, from, to, subject, text string) {
@@ -81,6 +82,7 @@ func (n *Notifier) loggerEmailSMTP(ch chan *Msg, server, username, password, fro
 	var throttleTimer *time.Timer
 
 	severityTrack := DEBUG
+	hostname, _ := os.Hostname()
 
 	for {
 		var throttleC <-chan time.Time
@@ -126,7 +128,7 @@ func (n *Notifier) loggerEmailSMTP(ch chan *Msg, server, username, password, fro
 				continue
 			}
 			mbuf, abuf = nil, nil
-			sevsubject := subject + " [" + severityTrack.String() + "]"
+			sevsubject := subject + " [" + hostname + "] [" + severityTrack.String() + "]"
 			severityTrack = DEBUG
 			lastFlush = time.Now()
 			if throttleTimer != nil {
@@ -143,7 +145,7 @@ func (n *Notifier) loggerEmailSMTP(ch chan *Msg, server, username, password, fro
 	}
 	// send the last entries:
 	if text := makeEmailText(mbuf, abuf); text != "" {
-		sevsubject := subject + " [" + severityTrack.String() + "]"
+		sevsubject := subject + " [" + hostname + "] [" + severityTrack.String() + "]"
 		n.wg.Add(1)
 		go n.sendEmailSMTP(server, username, password, from, to, sevsubject, text)
 	}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.6"
+const VERSION = "0.4.7"


### PR DESCRIPTION
HI,

This commit adds the hostname to the log output and email subject.

I have multiple machines that are monitored with zfswatcher, and I have enabled email notification so I am informed when something goes wrong. The problem is that it is not immediately clear what host sent the mail, since only the pool name is logged.

Regards,
Martin Balvers