### PR TITLE
Use local notifier package instead of outdated github.com/damicon/zfs…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ VERSION		= $(shell fgrep VERSION version.go | cut -d\" -f2)
 all: zfswatcher
 
 zfswatcher:
+ifeq (,$(wildcard ./go.mod))
+	$(GO) mod init zfswatcher
+endif
 	$(GO) get -d
 	$(GO) build -o $@
 

--- a/leds.go
+++ b/leds.go
@@ -24,7 +24,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/damicon/zfswatcher/notifier"
+	"zfswatcher/notifier"
 	"os"
 	"os/exec"
 	"strings"

--- a/setup.go
+++ b/setup.go
@@ -25,7 +25,7 @@ import (
 	"gopkg.in/gcfg.v1"
 	"errors"
 	"fmt"
-	"github.com/damicon/zfswatcher/notifier"
+	"zfswatcher/notifier"
 	"github.com/ogier/pflag"
 	"os"
 	"strings"

--- a/util.go
+++ b/util.go
@@ -24,7 +24,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/damicon/zfswatcher/notifier"
+	"zfswatcher/notifier"
 	"io"
 	"os"
 	"os/exec"

--- a/webpagehandlers.go
+++ b/webpagehandlers.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"regexp"
 	auth "github.com/abbot/go-http-auth"
-	"github.com/damicon/zfswatcher/notifier"
+	"zfswatcher/notifier"
 	"html/template"
 	"net/http"
 	"sync"

--- a/webserver.go
+++ b/webserver.go
@@ -24,7 +24,7 @@ package main
 import (
 	"fmt"
 	auth "github.com/abbot/go-http-auth"
-	"github.com/damicon/zfswatcher/notifier"
+	"zfswatcher/notifier"
 	"html/template"
 	"math/rand"
 	"net/http"

--- a/zfswatcher.go
+++ b/zfswatcher.go
@@ -30,7 +30,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/damicon/zfswatcher/notifier"
+	"zfswatcher/notifier"
 	"os"
 	"os/signal"
 	"runtime"

--- a/zparse.go
+++ b/zparse.go
@@ -23,7 +23,7 @@ package main
 
 import (
 	"errors"
-	"github.com/damicon/zfswatcher/notifier"
+	"zfswatcher/notifier"
 	"io"
 	"runtime"
 	"strings"


### PR DESCRIPTION
Use local notifier package instead of outdated github.com/damicon/zfswatcher/notifier.

Recent changes in zfswatcher/notifier were not incorporated when building the package because  the notifier package was pulled from github.com/damicon/zfswatcher/notifier.
I have changed the files that used the damicon version to point to the local version. I also had to change the Makefile so it would do a 'go mod init zfswatcher' and create a go.mod file. Without that go would not find the notifier package.
If there is a better way to do this, feel free to change ;)